### PR TITLE
Solving some small deployement issues

### DIFF
--- a/src/learning-token-backend/src/utils/kaledio.ts
+++ b/src/learning-token-backend/src/utils/kaledio.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv'
 dotenv.config()
 const kaledio =
     process.env.KALEIDO_HD_WALLET_RPC_URL +
-    'api/v1/wallets/:walletId/accounts/:accountIndex'
+    '/api/v1/wallets/:walletId/accounts/:accountIndex'
 // ;('https://u0k1dk029t:hU5ERoJz_xLvmQzr8h1jmLr6a3Afn4Oa6T4NHjKJ2ro@u0jtyl6s8p-u0gt6e2xu2-hdwallet.us0-aws.kaleido.io/api/v1/wallets/:walletId/accounts/:accountIndex')
 export const getWallet = async (type: string, id: number) => {
     //decrement id by 1 since the index starts from 0

--- a/src/learning-token/hardhat.config.ts
+++ b/src/learning-token/hardhat.config.ts
@@ -54,9 +54,9 @@ const config: HardhatUserConfig = {
     //   // gas: 124500 // adjust as necessary
     // },
     kaleido: {
-      url: KALEIDO_RPC_URL,
-      chainId: 1513174332,
-      accounts: [KALEIDO_PRIV_KEY],
+      url: process.env.KALEIDO_RPC_URL,
+      chainId: parseInt(process.env.KALEIDO_CHAIN_ID || "0"),
+      accounts: [process.env.KALEDIO_PRIV_KEY || ""]
       // gasPrice: 80000000, // adjust as necessary
       // gas: 124500 // adjust as necessary
     },
@@ -72,7 +72,7 @@ const config: HardhatUserConfig = {
   },
 
   etherscan: {
-    apiKey: POLYGON_API_KEY,
+    apiKey: process.env.POLYGON_API_KEY,
     //   constructorArguments: [owners, numConfirmationsRequired],
   },
 };


### PR DESCRIPTION
added '/' in additional url defined to access hd wallets in 'kaledio.ts' of learning-token-backend to avoid 'ENOTFOUND' error
![Screenshot from 2025-05-12 12-22-08](https://github.com/user-attachments/assets/1389a4c3-beac-435a-8828-5b19c25599d3)

and removed the hardcoded kaleido and polygon credentials in 'hardhat.config.ts' of learning-token directory and replace them to access them from '.env' cause they are already defined there