### PR TITLE
chore(deps): hold back astro and next majors in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,20 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # Majors that need a manual migration before they can land, so they are
+      # held back to keep the grouped PRs mergeable.
+      #
+      # astro 5 -> 7 breaks `npm ci`: @astrojs/tailwind@6 declares
+      # `peer astro: ^3 || ^4 || ^5`. Clearing the astro advisories needs
+      # >= 7.1.0 *and* a move to @tailwindcss/vite. Tracked separately.
+      #
+      # NOTE: ignore also suppresses security updates for these packages.
+      # Remove each entry as soon as its migration is done.
+      - dependency-name: "astro"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "next"
+        update-types: ["version-update:semver-major"]
 
   # ------------------------------------------------------------- docker ----
   # Dockerfiles under src/learning-token-backend, src/learning-token-dashboard,


### PR DESCRIPTION
The grouped npm PRs keep pulling in major upgrades that cannot be merged
as-is, which blocks the compatible security bumps travelling with them.

astro 5 -> 7 is the concrete blocker: @astrojs/tailwind@6 declares
peer astro "^3.0.0 || ^4.0.0 || ^5.0.0", so npm ci fails outright with
ERESOLVE and the Pages build job never gets to run. Clearing the astro
advisories needs >= 7.1.0 together with a move to @tailwindcss/vite,
which is its own change.

Holding both majors lets the axios, express, postcss and
solidity-coverage bumps land on their own.

Signed-off-by: Alberto Ceballos <alberto@danil.ai>
